### PR TITLE
Item id filter

### DIFF
--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
@@ -107,7 +107,7 @@ public class ItemFilters {
     }
 
     /**
-     * Filters by an Identifier (item id)
+     * Filters by Identifier (item id)
      * @param query The query
      * @return A list of matching item stacks
      */
@@ -132,7 +132,7 @@ public class ItemFilters {
     }
 
     /**
-     * Filters by an Identifier (item id)
+     * Filters by Identifier (item id)
      * @param query The query
      * @return Whether the item matches the item id
      */

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
@@ -93,8 +93,9 @@ public class ItemFilters {
 
     /**
      * Filters by mod name
+     * @param stack The item stack
      * @param query The query
-     * @return Whether the item matches the mod name
+     * @return Whether the item stack matches the mod name
      */
     protected static boolean modName(ItemStack stack, String query) {
         String modName = ReliableRecipeViewerClient.resolver().getModNameForItem(stack);
@@ -133,8 +134,9 @@ public class ItemFilters {
 
     /**
      * Filters by Identifier (item id)
+     * @param stack The item stack
      * @param query The query
-     * @return Whether the item matches the item id
+     * @return Whether the item stack matches the item id
      */
     protected static boolean id(ItemStack stack, String query) {
         String itemId = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString().toLowerCase();
@@ -177,8 +179,9 @@ public class ItemFilters {
 
     /**
      * Filters by an items tags
+     * @param stack The item stack
      * @param query The query
-     * @return Whether the item matches the items tags
+     * @return Whether the item stack matches the items tags
      */
     protected static boolean tag(ItemStack stack, String query) {
         AtomicBoolean result = new AtomicBoolean(false);

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
@@ -3,7 +3,6 @@ package cc.cassian.rrv.common.overlay.itemlist.view;
 import cc.cassian.rrv.client.ReliableRecipeViewerClient;
 import cc.cassian.rrv.api.recipe.ItemView;
 import cc.cassian.rrv.common.config.Configs;
-import cc.cassian.rrv.common.config.instances.ClientConfig;
 import cc.cassian.rrv.common.extra.FluidStack;
 import cc.cassian.rrv.common.recipe.ClientRecipeCache;
 import net.minecraft.client.Minecraft;
@@ -28,7 +27,7 @@ public class ItemFilters {
     /**
      * Filters just by the items display name and tooltip
      * @param query The query
-     * @return A list of matching itemstacks
+     * @return A list of matching item stacks
      */
     protected static List<ItemStack> defaultFilter(String query) {
         List<ItemStack> firstPrio = new ArrayList<>();
@@ -62,11 +61,11 @@ public class ItemFilters {
     }
 
     /**
-     * Filters by modid
+     * Filters by mod name
      * @param query The query
-     * @return A list of matching itemstacks
+     * @return A list of matching item stacks
      */
-    protected static List<ItemStack> modId(String query) {
+    protected static List<ItemStack> modName(String query) {
 
         List<ItemStack> firstPrio = new ArrayList<>();
         List<ItemStack> secondPrio = new ArrayList<>();
@@ -93,28 +92,59 @@ public class ItemFilters {
     }
 
     /**
-     * Filters by modid
+     * Filters by mod name
      * @param query The query
-     * @return A list of matching itemstacks
+     * @return Whether the item matches the mod id
      */
-    protected static boolean modId(ItemStack stack, String query) {
+    protected static boolean modName(ItemStack stack, String query) {
         String modName = ReliableRecipeViewerClient.resolver().getModNameForItem(stack);
         if (modName == null)
             return false;
 
         modName = modName.toLowerCase();
 
-        if (modName.startsWith(query.toLowerCase()))
-            return true;
-        else if (modName.contains(query.toLowerCase()))
-            return true;
-        return false;
+        return modName.startsWith(query.toLowerCase()) || modName.contains(query.toLowerCase());
+    }
+
+    /**
+     * Filters by an Identifier (item id)
+     * @param query The query
+     * @return A list of matching item stacks
+     */
+    protected static List<ItemStack> id(String query) {
+        List<ItemStack> firstPrio = new ArrayList<>();
+        List<ItemStack> secondPrio = new ArrayList<>();
+
+        for (ItemStack stack : fullStackList()) {
+
+            String itemId = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString().toLowerCase();
+
+            if (itemId.startsWith(query.toLowerCase()))
+                firstPrio.add(stack);
+            else if (itemId.contains(query.toLowerCase()))
+                secondPrio.add(stack);
+        }
+
+        List<ItemStack> results = new ArrayList<>();
+        results.addAll(firstPrio);
+        results.addAll(secondPrio);
+        return results;
+    }
+
+    /**
+     * Filters by an Identifier (item id)
+     * @param query The query
+     * @return Whether the item matches the item id
+     */
+    protected static boolean id(ItemStack stack, String query) {
+        String itemId = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString().toLowerCase();
+        return itemId.startsWith(query.toLowerCase()) || itemId.contains(query.toLowerCase());
     }
 
     /**
      * Filters by an items tags
      * @param query The query
-     * @return A list of matching itemstacks
+     * @return A list of matching item stacks
      */
     protected static List<ItemStack> tag(String query) {
         List<ItemStack> firstPrio = new ArrayList<>();
@@ -148,7 +178,7 @@ public class ItemFilters {
     /**
      * Filters by an items tags
      * @param query The query
-     * @return A list of matching itemstacks
+     * @return Whether the item matches the items tags
      */
     protected static boolean tag(ItemStack stack, String query) {
         AtomicBoolean result = new AtomicBoolean(false);
@@ -167,8 +197,6 @@ public class ItemFilters {
         }
         return result.get();
     }
-
-
 
     /**
      * Returns the matching level of the itemstacks tooltip with the query

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemFilters.java
@@ -94,7 +94,7 @@ public class ItemFilters {
     /**
      * Filters by mod name
      * @param query The query
-     * @return Whether the item matches the mod id
+     * @return Whether the item matches the mod name
      */
     protected static boolean modName(ItemStack stack, String query) {
         String modName = ReliableRecipeViewerClient.resolver().getModNameForItem(stack);

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
@@ -32,7 +32,6 @@ import net.minecraft.world.item.ItemStack;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ItemViewOverlay extends AbstractRrvItemListOverlay {
 
@@ -168,7 +167,10 @@ public class ItemViewOverlay extends AbstractRrvItemListOverlay {
 
             for (String query : newQuery.split(" ")) {
                 if (query.startsWith("@")) {
-                    this.availableItems.removeIf(stack-> !ItemFilters.modId(stack, query.substring(1)));
+                    this.availableItems.removeIf(stack-> !ItemFilters.modName(stack, query.substring(1)));
+                }
+                else if (query.startsWith(":")) {
+                    this.availableItems.removeIf(stack-> ItemFilters.id(stack, query.substring(1)));
                 }
                 else if (query.startsWith("#")) {
                     this.availableItems.removeIf(stack-> !ItemFilters.tag(stack, query.substring(1)));
@@ -177,7 +179,9 @@ public class ItemViewOverlay extends AbstractRrvItemListOverlay {
         // standard filtering
         } else {
             if (newQuery.startsWith("@"))
-                this.availableItems = ItemFilters.modId(newQuery.substring(1));
+                this.availableItems = ItemFilters.modName(newQuery.substring(1));
+            else if (newQuery.startsWith(":"))
+                this.availableItems = ItemFilters.id(newQuery.substring(1));
             else if (newQuery.startsWith("#"))
                 this.availableItems = ItemFilters.tag(newQuery.substring(1));
             else

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
@@ -158,7 +158,7 @@ public class ItemViewOverlay extends AbstractRrvItemListOverlay {
             ArrayList<String> objects = new ArrayList<>();
 
             for (String query : newQuery.split(" ")) {
-                if (!query.startsWith("@") && !query.startsWith("#") && !query.startsWith(":")) {
+                if (!query.startsWith("@") && !query.startsWith(":") && !query.startsWith("#")) {
                     objects.add(query);
                 }
             }

--- a/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/itemlist/view/ItemViewOverlay.java
@@ -158,7 +158,7 @@ public class ItemViewOverlay extends AbstractRrvItemListOverlay {
             ArrayList<String> objects = new ArrayList<>();
 
             for (String query : newQuery.split(" ")) {
-                if (!query.startsWith("@") && !query.startsWith("#")) {
+                if (!query.startsWith("@") && !query.startsWith("#") && !query.startsWith(":")) {
                     objects.add(query);
                 }
             }
@@ -170,7 +170,7 @@ public class ItemViewOverlay extends AbstractRrvItemListOverlay {
                     this.availableItems.removeIf(stack-> !ItemFilters.modName(stack, query.substring(1)));
                 }
                 else if (query.startsWith(":")) {
-                    this.availableItems.removeIf(stack-> ItemFilters.id(stack, query.substring(1)));
+                    this.availableItems.removeIf(stack-> !ItemFilters.id(stack, query.substring(1)));
                 }
                 else if (query.startsWith("#")) {
                     this.availableItems.removeIf(stack-> !ItemFilters.tag(stack, query.substring(1)));


### PR DESCRIPTION
Support filtering by item ID starting with `:`, like `:stone` `:testmod:testitem `.
Also clean some docs.