### PR TITLE
Optimize RRV Overlay initialization and fix edge case crash

### DIFF
--- a/src/main/java/cc/cassian/rrv/client/ReliableRecipeViewerClient.java
+++ b/src/main/java/cc/cassian/rrv/client/ReliableRecipeViewerClient.java
@@ -74,11 +74,16 @@ public class ReliableRecipeViewerClient {
     public static MutableComponent addNamespaceTooltip(ItemStack stack, List<Component> tooltip, boolean inItemView) {
         if (!ModCompat.hasModNamespaceModsInstalled()) {
             MutableComponent namespace = Component.literal(Platform.INSTANCE.getModNameForItem(stack)).withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC);
-            if (((inItemView && Configs.CLIENT_SETTINGS.showNamespaceTooltip().equals(NamespaceTooltip.IN_ITEM_VIEW)) || Configs.CLIENT_SETTINGS.showNamespaceTooltip().equals(NamespaceTooltip.SHOW)) && !tooltip.contains(namespace))
-                tooltip.addLast(namespace);
-            return namespace;
+            if (((inItemView && Configs.CLIENT_SETTINGS.showNamespaceTooltip().equals(NamespaceTooltip.IN_ITEM_VIEW)) ||
+                    Configs.CLIENT_SETTINGS.showNamespaceTooltip().equals(NamespaceTooltip.SHOW))) {
+                if (!tooltip.contains(namespace)) {
+                    tooltip.addLast(namespace);
+                }
+                return namespace;
+            } else if (tooltip.contains(namespace)) {
+                return namespace;
+            }
         }
         return null;
-
     }
 }

--- a/src/main/java/cc/cassian/rrv/client/util/RRVClientUtil.java
+++ b/src/main/java/cc/cassian/rrv/client/util/RRVClientUtil.java
@@ -3,10 +3,13 @@ package cc.cassian.rrv.client.util;
 import cc.cassian.rrv.api.recipe.ReliableClientRecipe;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class RRVClientUtil {
+    public static final Identifier CONTAINER = Identifier.withDefaultNamespace("container");
+
     public static void setScreen(Screen newScreen) {
         //? if >26.1 {
         /*Minecraft.getInstance().gui.setScreen(newScreen);

--- a/src/main/java/cc/cassian/rrv/client/util/RRVExtendedContainerScreen.java
+++ b/src/main/java/cc/cassian/rrv/client/util/RRVExtendedContainerScreen.java
@@ -1,0 +1,15 @@
+package cc.cassian.rrv.client.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * This interface is used to give valid entry points for Mixins.
+ */
+@ApiStatus.Internal
+public interface RRVExtendedContainerScreen {
+	default void rrv$callInit() {
+		throw new UnsupportedOperationException();
+	}
+
+	boolean rrv$triggerInitLater();
+}

--- a/src/main/java/cc/cassian/rrv/common/mixin/client/gui/screens/inventory/MixinAbstractContainerScreen.java
+++ b/src/main/java/cc/cassian/rrv/common/mixin/client/gui/screens/inventory/MixinAbstractContainerScreen.java
@@ -3,6 +3,7 @@ package cc.cassian.rrv.common.mixin.client.gui.screens.inventory;
 import cc.cassian.rrv.api.ActionType;
 import cc.cassian.rrv.client.util.RRVClientUtil;
 import cc.cassian.rrv.client.ReliableRecipeViewerClient;
+import cc.cassian.rrv.client.util.RRVExtendedContainerScreen;
 import cc.cassian.rrv.common.overlay.AbstractRrvOverlay;
 import cc.cassian.rrv.common.overlay.BlockingGuiComponent;
 import cc.cassian.rrv.common.overlay.OverlayManager;
@@ -18,7 +19,6 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.client.input.KeyEvent;
@@ -37,7 +37,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = AbstractContainerScreen.class, priority = 900)
-public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMenu> extends Screen implements MenuAccess<T> {
+public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMenu> extends Screen
+        implements MenuAccess<T>, RRVExtendedContainerScreen {
 
 
     @Shadow
@@ -66,28 +67,29 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
         super(component);
     }
 
-
     @Inject(method = "init", at = @At("TAIL"))
     private void injectOverlay$0(CallbackInfo ci) {
+        // In some screens we initialize after the screen button init
+        if (this.rrv$triggerInitLater()) return;
 
-        //In recipe book screens we initialize after the recipe button init
-        if ((Object) this instanceof AbstractRecipeBookScreen)
-            return;
+        this.rrv$callInit();
+    }
 
-        AbstractRrvOverlay.InventoryPositionInfo info = new AbstractRrvOverlay.InventoryPositionInfo((AbstractContainerScreen<? extends AbstractContainerMenu>) (Object) this, this.width, this.height, this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
+    @Override
+    public final void rrv$callInit() {
+        AbstractRrvOverlay.InventoryPositionInfo info = new AbstractRrvOverlay.InventoryPositionInfo(
+                (AbstractContainerScreen<? extends AbstractContainerMenu>) (Object) this,
+                this.width, this.height, this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
 
         OverlayManager.INSTANCE.setGuiBlocking(new BlockingGuiComponent(
-                Identifier.withDefaultNamespace("container"),
+                RRVClientUtil.CONTAINER,
                 info.leftPos(),
                 info.topPos(),
                 info.imageWidth(),
                 info.imageHeight()
         ));
-
-        OverlayManager.INSTANCE.checkForScreenChange(info);
-        OverlayManager.INSTANCE.updateOverlaysAndWidgets();
+        OverlayManager.INSTANCE.setCurrentInvInfo(info);
         this.updateWidgets();
-
     }
 
     @Inject(method = "extractContents", at = @At("TAIL"))
@@ -106,7 +108,7 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
         ));
 
         if (OverlayManager.INSTANCE.checkForScreenChange(info))
-            OverlayManager.INSTANCE.updateOverlaysAndWidgets();
+            OverlayManager.INSTANCE.updateOverlaysAndWidgets(false);
 
         if (OverlayManager.INSTANCE.hasQueuedWidgetUpdate())
             this.updateWidgets();
@@ -160,7 +162,6 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
         return super.mouseClicked(mouseButtonEvent, b) | OverlayManager.INSTANCE.mouseClicked(mouseButtonEvent, b);
     }
 
-
     @Inject(method = "onClose", at = @At("HEAD"), cancellable = true)
     private void injectOverlay$4(CallbackInfo ci) {
         OverlayManager.INSTANCE.oldWidgets().clear();
@@ -210,5 +211,10 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
 
         OverlayManager.INSTANCE.setQueuedWidgetUpdate(false);
 
+    }
+
+    @Override
+    public boolean rrv$triggerInitLater() {
+        return false;
     }
 }

--- a/src/main/java/cc/cassian/rrv/common/mixin/client/gui/screens/inventory/MixinAbstractRecipeBookScreen.java
+++ b/src/main/java/cc/cassian/rrv/common/mixin/client/gui/screens/inventory/MixinAbstractRecipeBookScreen.java
@@ -1,31 +1,26 @@
 package cc.cassian.rrv.common.mixin.client.gui.screens.inventory;
 
+import cc.cassian.rrv.client.util.RRVExtendedContainerScreen;
 import cc.cassian.rrv.common.config.Configs;
-import cc.cassian.rrv.common.overlay.AbstractRrvOverlay;
-import cc.cassian.rrv.common.overlay.BlockingGuiComponent;
 import cc.cassian.rrv.common.overlay.OverlayManager;
 import net.minecraft.client.gui.components.EditBox;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.components.events.GuiEventListener;
-import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
 import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.RecipeBookMenu;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(AbstractRecipeBookScreen.class)
-public abstract class MixinAbstractRecipeBookScreen<T extends RecipeBookMenu> extends AbstractContainerScreen<T> implements RecipeUpdateListener {
+public abstract class MixinAbstractRecipeBookScreen<T extends RecipeBookMenu> extends AbstractContainerScreen<T>
+        implements RecipeUpdateListener, RRVExtendedContainerScreen {
 
     public MixinAbstractRecipeBookScreen(T abstractContainerMenu, Inventory inventory, Component component) {
         super(abstractContainerMenu, inventory, component);
@@ -34,21 +29,7 @@ public abstract class MixinAbstractRecipeBookScreen<T extends RecipeBookMenu> ex
     @SuppressWarnings("unchecked")
     @Inject(method = "init", at = @At("TAIL"))
     private void injectOverlay$0(CallbackInfo ci) {
-
-        AbstractRrvOverlay.InventoryPositionInfo info = new AbstractRrvOverlay.InventoryPositionInfo((AbstractRecipeBookScreen<T>) (Object) this, this.width, this.height, this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
-
-        OverlayManager.INSTANCE.setGuiBlocking(new BlockingGuiComponent(
-                Identifier.withDefaultNamespace("container"),
-                info.leftPos(),
-                info.topPos(),
-                info.imageWidth(),
-                info.imageHeight()
-        ));
-
-        OverlayManager.INSTANCE.checkForScreenChange(info);
-        OverlayManager.INSTANCE.updateOverlaysAndWidgets();
-        this.rrv$updateWidgets();
-
+        this.rrv$callInit();
     }
 
     @Inject(method = "lambda$initButton$0", at = @At("HEAD"), cancellable = true)
@@ -76,25 +57,8 @@ public abstract class MixinAbstractRecipeBookScreen<T extends RecipeBookMenu> ex
             cir.setReturnValue(true);
     }
 
-
-    @Unique
-    private void rrv$updateWidgets() {
-        OverlayManager.INSTANCE.oldWidgets().forEach(eventListener -> {
-
-            if (eventListener.isFocused())
-                this.setFocused(null);
-
-            this.removeWidget(eventListener);
-        });
-        OverlayManager.INSTANCE.oldWidgets().clear();
-
-        OverlayManager.INSTANCE.screenContextMap().forEach((abstractRrvOverlay, screenContext) -> {
-            screenContext.renderables().forEach(eventListener -> this.addRenderableWidget((GuiEventListener & Renderable & NarratableEntry) eventListener));
-            screenContext.nonRenderables().forEach(eventListener -> this.addWidget((GuiEventListener & NarratableEntry) eventListener));
-        });
-
-        OverlayManager.INSTANCE.setQueuedWidgetUpdate(false);
-
+    @Override
+    public boolean rrv$triggerInitLater() {
+        return true;
     }
-
 }

--- a/src/main/java/cc/cassian/rrv/common/overlay/OverlayManager.java
+++ b/src/main/java/cc/cassian/rrv/common/overlay/OverlayManager.java
@@ -28,6 +28,7 @@ public class OverlayManager {
     private final List<GuiEventListener> oldWidgets = new ArrayList<>();
     private final HashMap<AbstractRrvOverlay, AbstractRrvOverlay.ScreenContext> screenContextMap = new HashMap<>();
     private boolean queuedWidgetUpdate = false;
+    private boolean newScreenQueued = false;
 
     private final List<BlockingGuiComponent> guiBlockings = new ArrayList<>();
 
@@ -42,6 +43,7 @@ public class OverlayManager {
 
     public void setCurrentInvInfo(AbstractRrvOverlay.InventoryPositionInfo info) {
         this.currentInvInfo = info;
+        this.newScreenQueued = true;
     }
 
     public boolean checkForScreenChange(AbstractRrvOverlay.InventoryPositionInfo newInfo) {
@@ -50,7 +52,8 @@ public class OverlayManager {
             return true;
         }
 
-        return false;
+        // Must return true if screen changed and components aren't updated
+        return this.newScreenQueued;
     }
 
     //Update all overlays and collect widgets
@@ -66,7 +69,10 @@ public class OverlayManager {
     }
 
     //Update widget lists
-    public void updateOverlaysAndWidgets() {
+    public void updateOverlaysAndWidgets(boolean always) {
+        if (!always && !this.newScreenQueued)
+            return;
+        this.newScreenQueued = false;
         if (this.currentInfo() == null)
             return;
 
@@ -247,7 +253,7 @@ public class OverlayManager {
         this.guiBlockings.removeIf(blockingGuiComponent -> blockingGuiComponent.id().equals(id));
 
         if (updateOverlays) {
-            this.updateOverlaysAndWidgets();
+            this.updateOverlaysAndWidgets(true);
         }
 
     }
@@ -256,18 +262,18 @@ public class OverlayManager {
         this.guiBlockings.removeIf(blockingGuiComponent -> filter.test(blockingGuiComponent.id()));
 
         if (updateOverlays) {
-            this.updateOverlaysAndWidgets();
+            this.updateOverlaysAndWidgets(true);
         }
 
     }
 
     public void setGuiBlocking(BlockingGuiComponent comp) {
-        List<BlockingGuiComponent> old = new ArrayList<>(this.guiBlockings);
+        HashSet<BlockingGuiComponent> old = new HashSet<>(this.guiBlockings);
         this.removeGuiBlocking(comp.id(), false);
         this.guiBlockings.add(comp);
 
-        if (!(new HashSet<>(old).containsAll(this.guiBlockings) && old.size() == this.guiBlockings.size())) {
-            this.updateOverlaysAndWidgets();
+        if (!(old.containsAll(this.guiBlockings) && old.size() == this.guiBlockings.size())) {
+            this.setQueuedWidgetUpdate(true);
         }
 
 


### PR DESCRIPTION
- Fixed a crash when RRV is alone and mod tooltips are disabled
- Optimize overlay initialization (Help but does **not** fix [**#23**](https://github.com/cassiancc/ReliableRecipeViewer/issues/23))
- Cache the resource location for "minecraft:container" key
- Improve mixin formatting

Please review my PR and tell me if there is anything you need me to change.

I can also split this MR to multiple commits if needed.

The multi-version nature of v8 is very cool!