### PR TITLE
Improve exception handling of invalid recipes for some builtin types.

### DIFF
--- a/src/main/java/cc/cassian/rrv/client/builtin/BuiltInReliableRecipeViewerClientIntegration.java
+++ b/src/main/java/cc/cassian/rrv/client/builtin/BuiltInReliableRecipeViewerClientIntegration.java
@@ -4,6 +4,7 @@ import cc.cassian.rrv.api.CommonTags;
 import cc.cassian.rrv.api.ReliableRecipeViewerClientPlugin;
 import cc.cassian.rrv.api.recipe.ItemView;
 import cc.cassian.rrv.api.recipe.ReliableClientRecipe;
+import cc.cassian.rrv.common.ReliableRecipeViewer;
 import cc.cassian.rrv.common.builtin.blasting.BlastingClientRecipe;
 import cc.cassian.rrv.common.builtin.brewing.BrewingClientRecipe;
 import cc.cassian.rrv.common.builtin.burning.BurningClientRecipe;
@@ -57,7 +58,6 @@ import net.minecraft.world.item.component.DyedItemColor;
 import net.minecraft.world.item.component.Fireworks;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.item.enchantment.Repairable;
-import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.FuelValues;
 import net.minecraft.world.level.block.entity.PotDecorations;
@@ -153,123 +153,116 @@ public class BuiltInReliableRecipeViewerClientIntegration implements ReliableRec
         ClientRecipeManager.INSTANCE.getRecipesForType(RecipeType.CRAFTING).forEach(craftingRecipeHolder -> {
             var id = craftingRecipeHolder.id().identifier();
             var recipe = craftingRecipeHolder.value();
-            if (recipe instanceof ShapelessRecipe shapelessRecipe)
-                recipeList.add(new CraftingClientRecipe.Builder(id, shapelessRecipe.ingredients.stream().map(SlotContent::of).toList()).setResult(shapelessRecipe.result).build());
+            try {
+                if (recipe instanceof ShapelessRecipe shapelessRecipe) {
+                    recipeList.add(new CraftingClientRecipe.Builder(id, shapelessRecipe.ingredients.stream()
+                            .map(SlotContent::of).toList()).setResult(shapelessRecipe.result).build());
+                } else if (recipe instanceof ShapedRecipe shapedRecipe) {
+                    HashMap<Integer, SlotContent> ingredients = new HashMap<>();
+                    int i = 0;
+                    for (int y = 0; y < 3; y++) {
+                        for (int x = 0; x < 3; x++) {
 
+                            if (x >= shapedRecipe.getWidth() || y >= shapedRecipe.getHeight()) {
+                                continue;
+                            }
 
-            if (recipe instanceof ShapedRecipe shapedRecipe) {
+                            if (shapedRecipe.getIngredients().get(i).isPresent())
+                                ingredients.put(x + y * 3, SlotContent.of(shapedRecipe.getIngredients().get(i).get()));
 
-                HashMap<Integer, SlotContent> ingredients = new HashMap<>();
-
-                int i = 0;
-                for (int y = 0; y < 3; y++) {
-                    for (int x = 0; x < 3; x++) {
-
-                        if (x >= shapedRecipe.getWidth() || y >= shapedRecipe.getHeight()) {
-                            continue;
+                            i++;
                         }
-
-                        if (shapedRecipe.getIngredients().get(i).isPresent())
-                            ingredients.put(x + y * 3, SlotContent.of(shapedRecipe.getIngredients().get(i).get()));
-
-                        i++;
                     }
-                }
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setSize(shapedRecipe.getWidth(), shapedRecipe.getHeight()).setResult(shapedRecipe.result).build());
+                } else if (recipe instanceof TransmuteRecipe) {
+                    TransmuteRecipeAccessor accessor = (TransmuteRecipeAccessor) recipe;
 
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setSize(shapedRecipe.getWidth(), shapedRecipe.getHeight()).setResult(shapedRecipe.result).build());
-            }
+                    List<ItemStackTemplate> results = new ArrayList<>();
 
-            else if (recipe instanceof TransmuteRecipe) {
-                TransmuteRecipeAccessor accessor = (TransmuteRecipeAccessor) recipe;
+                    var ingredients = getItemsFromIngredient(accessor.getInput());
 
-                List<ItemStackTemplate> results = new ArrayList<>();
+                    ingredients.forEach(_ -> results.add(accessor.getResult()));
 
-                var ingredients = getItemsFromIngredient(accessor.getInput());
+                    if (!ingredients.isEmpty() && !results.isEmpty())
+                        recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getInput(), accessor.getMaterial()).setResult(results).build());
 
-                ingredients.forEach(_ -> results.add(accessor.getResult()));
+                } else if (recipe instanceof DyeRecipe) {
+                    DyeRecipeAccessor accessor = (DyeRecipeAccessor) recipe;
 
-                if (!ingredients.isEmpty() && !results.isEmpty())
-                    recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getInput(), accessor.getMaterial()).setResult(results).build());
+                    List<Item> ingredients = getItemsFromIngredient(accessor.getTarget());
 
-            }
-            else if (recipe instanceof DyeRecipe) {
-                DyeRecipeAccessor accessor = (DyeRecipeAccessor) recipe;
-
-                List<Item> ingredients = getItemsFromIngredient(accessor.getTarget());
-
-                List<ItemStackTemplate> results = new ArrayList<>();
-                for (Item ingredient : ingredients) {
-                    for (DyeColor dyeColor : DyeColor.values()) {
-                        results.add(ItemStackTemplate.fromNonEmptyStack(DyedItemColor.applyDyes(ingredient.getDefaultInstance(), Collections.singletonList(dyeColor))));
+                    List<ItemStackTemplate> results = new ArrayList<>();
+                    for (Item ingredient : ingredients) {
+                        for (DyeColor dyeColor : DyeColor.values()) {
+                            results.add(ItemStackTemplate.fromNonEmptyStack(DyedItemColor.applyDyes(ingredient.getDefaultInstance(), Collections.singletonList(dyeColor))));
+                        }
                     }
-                }
 
-                recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getTarget(), accessor.getDye()).setResult(results).setDependentIndex(1).build());
-            }
-            else if (recipe instanceof ImbueRecipe) {
-                ImbueRecipeAccessor accessor = (ImbueRecipeAccessor) recipe;
+                    recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getTarget(), accessor.getDye()).setResult(results).setDependentIndex(1).build());
+                } else if (recipe instanceof ImbueRecipe) {
+                    ImbueRecipeAccessor accessor = (ImbueRecipeAccessor) recipe;
 
 
-                Registry<Potion> potionRegistry = level.registryAccess().lookupOrThrow(Registries.POTION);
-                potionRegistry.forEach(potion -> {
-                    Holder<Potion> potionHolder = potionRegistry.wrapAsHolder(potion);
-                    var items = getItemsFromIngredient(accessor.getSource()).stream().map(item->PotionContents.createItemStack(item, potionHolder)).toList();
-                    HashMap<Integer, SlotContent> ingredients = fillCraftingGrid(SlotContent.of(items), SlotContent.of(accessor.getMaterial()));
+                    Registry<Potion> potionRegistry = level.registryAccess().lookupOrThrow(Registries.POTION);
+                    potionRegistry.forEach(potion -> {
+                        Holder<Potion> potionHolder = potionRegistry.wrapAsHolder(potion);
+                        var items = getItemsFromIngredient(accessor.getSource()).stream().map(item -> PotionContents.createItemStack(item, potionHolder)).toList();
+                        HashMap<Integer, SlotContent> ingredients = fillCraftingGrid(SlotContent.of(items), SlotContent.of(accessor.getMaterial()));
 
-                    ItemStack result = accessor.getResult().create().copyWithCount(8);
-                    result.set(DataComponents.POTION_CONTENTS, new PotionContents(potionHolder));
-                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(result)).setPriority(5).build());
-                });
-            }
-            else if (recipe instanceof DecoratedPotRecipe) {
-                DecoratedPotRecipeAccessor accessor = (DecoratedPotRecipeAccessor) recipe;
+                        ItemStack result = accessor.getResult().create().copyWithCount(8);
+                        result.set(DataComponents.POTION_CONTENTS, new PotionContents(potionHolder));
+                        recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(result)).setPriority(5).build());
+                    });
+                } else if (recipe instanceof DecoratedPotRecipe) {
+                    DecoratedPotRecipeAccessor accessor = (DecoratedPotRecipeAccessor) recipe;
 
-                HashMap<Integer, SlotContent> ingredients = new HashMap<>();
-                ingredients.put(1, SlotContent.of(accessor.getLeftPattern()));
-                ingredients.put(3, SlotContent.of(accessor.getRightPattern()));
-                ingredients.put(5, SlotContent.of(accessor.getBackPattern()));
-                ingredients.put(7, SlotContent.of(accessor.getFrontPattern()));
+                    HashMap<Integer, SlotContent> ingredients = new HashMap<>();
+                    ingredients.put(1, SlotContent.of(accessor.getLeftPattern()));
+                    ingredients.put(3, SlotContent.of(accessor.getRightPattern()));
+                    ingredients.put(5, SlotContent.of(accessor.getBackPattern()));
+                    ingredients.put(7, SlotContent.of(accessor.getFrontPattern()));
 
-                List<ItemStack> results = new ArrayList<>();
-                for (Item ingredient : getItemsFromIngredient(accessor.getFrontPattern())) {
-                    PotDecorations decorations = new PotDecorations(ingredient, ingredient, ingredient, ingredient);
-                    DataComponentPatch components = DataComponentPatch.builder().set(DataComponents.POT_DECORATIONS, decorations).build();
-                    results.add(accessor.getResult().apply(components));
-                }
-
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(results)).setDependentIndex(7).build());
-            }
-            else if (recipe instanceof BookCloningRecipe) {
-                BookCloningRecipeAccessor accessor = (BookCloningRecipeAccessor) recipe;
-                recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getSource(), accessor.getMaterial()).setResult(accessor.getResult().withCount(2)).build());
-            }
-            else if (recipe instanceof MapExtendingRecipe) {
-                MapExtendingRecipeAccessor accessor = (MapExtendingRecipeAccessor) recipe;
-                HashMap<Integer, SlotContent> ingredients = fillCraftingGrid(SlotContent.of(accessor.getMap()), SlotContent.of(accessor.getMaterial()));
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult())).build());
-            }
-            else if (recipe instanceof FireworkRocketRecipe) {
-                FireworkRocketRecipeAccessor accessor = (FireworkRocketRecipeAccessor) recipe;
-                List<SlotContent> ingredients = new ArrayList<>(List.of(SlotContent.of(accessor.getFuel()), SlotContent.of(accessor.getShell()), SlotContent.of(accessor.getStar())));
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult())).setPriority(20).build());
-                ingredients.addFirst(SlotContent.of(accessor.getFuel()));
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.FIREWORKS, new Fireworks(2, List.of())).build()))).setPriority(20).build());
-                ingredients.addFirst(SlotContent.of(accessor.getFuel()));
-                recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.FIREWORKS, new Fireworks(3, List.of())).build()))).setPriority(20).build());
-            }
-            else if (recipe instanceof ShieldDecorationRecipe) {
-                ShieldDecorationRecipeAccessor accessor = (ShieldDecorationRecipeAccessor) recipe;
-                ArrayList<ItemStack> results = new ArrayList<>();
-                for (Item item : getItemsFromIngredient(accessor.getBanner())) {
-                    if (item instanceof BannerItem bannerItem) {
-                        var dyeColor = bannerItem.getColor();
-                        results.add(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.BASE_COLOR, dyeColor).build()));
+                    List<ItemStack> results = new ArrayList<>();
+                    for (Item ingredient : getItemsFromIngredient(accessor.getFrontPattern())) {
+                        PotDecorations decorations = new PotDecorations(ingredient, ingredient, ingredient, ingredient);
+                        DataComponentPatch components = DataComponentPatch.builder().set(DataComponents.POT_DECORATIONS, decorations).build();
+                        results.add(accessor.getResult().apply(components));
                     }
+
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(results)).setDependentIndex(7).build());
+                } else if (recipe instanceof BookCloningRecipe) {
+                    BookCloningRecipeAccessor accessor = (BookCloningRecipeAccessor) recipe;
+                    recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getSource(), accessor.getMaterial()).setResult(accessor.getResult().withCount(2)).build());
+                } else if (recipe instanceof MapExtendingRecipe) {
+                    MapExtendingRecipeAccessor accessor = (MapExtendingRecipeAccessor) recipe;
+                    HashMap<Integer, SlotContent> ingredients = fillCraftingGrid(SlotContent.of(accessor.getMap()), SlotContent.of(accessor.getMaterial()));
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult())).build());
+                } else if (recipe instanceof FireworkRocketRecipe) {
+                    FireworkRocketRecipeAccessor accessor = (FireworkRocketRecipeAccessor) recipe;
+                    List<SlotContent> ingredients = new ArrayList<>(List.of(SlotContent.of(accessor.getFuel()), SlotContent.of(accessor.getShell()), SlotContent.of(accessor.getStar())));
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult())).setPriority(20).build());
+                    ingredients.addFirst(SlotContent.of(accessor.getFuel()));
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.FIREWORKS, new Fireworks(2, List.of())).build()))).setPriority(20).build());
+                    ingredients.addFirst(SlotContent.of(accessor.getFuel()));
+                    recipeList.add(new CraftingClientRecipe.Builder(id, ingredients).setResult(SlotContent.of(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.FIREWORKS, new Fireworks(3, List.of())).build()))).setPriority(20).build());
+                } else if (recipe instanceof ShieldDecorationRecipe) {
+                    ShieldDecorationRecipeAccessor accessor = (ShieldDecorationRecipeAccessor) recipe;
+                    ArrayList<ItemStack> results = new ArrayList<>();
+                    for (Item item : getItemsFromIngredient(accessor.getBanner())) {
+                        if (item instanceof BannerItem bannerItem) {
+                            var dyeColor = bannerItem.getColor();
+                            results.add(accessor.getResult().apply(DataComponentPatch.builder().set(DataComponents.BASE_COLOR, dyeColor).build()));
+                        }
+                    }
+                    recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getTarget(), accessor.getBanner()).setResult(SlotContent.of(results)).setDependentIndex(1).build());
+                } else if (recipe instanceof RepairItemRecipe) {
+                    // Repairing
+                    addRepairingRecipes(recipeList);
                 }
-                recipeList.add(new CraftingClientRecipe.Builder(id, accessor.getTarget(), accessor.getBanner()).setResult(SlotContent.of(results)).setDependentIndex(1).build());
-            } else if (recipe instanceof RepairItemRecipe) {
-                //Repairing
-                addRepairingRecipes(recipeList);
+            } catch (Exception e) {
+                // Log crafting recipes that throw out an exception on parse
+                ReliableRecipeViewer.LOGGER.atError().setCause(e).log(
+                        "Exception while parsing crafting recipe \"{}\"", id);
             }
         });
     }
@@ -299,13 +292,22 @@ public class BuiltInReliableRecipeViewerClientIntegration implements ReliableRec
         ClientRecipeManager.INSTANCE.getRecipesForType(RecipeType.SMITHING).forEach(smithingRecipeRecipeHolder -> {
             var smithingRecipe = smithingRecipeRecipeHolder.value();
 
-            if (smithingRecipe instanceof SmithingTrimRecipe trimRecipe)
-                recipeList.add(SmithingClientRecipe.trimRecipe(smithingRecipeRecipeHolder.id().identifier(), trimRecipe.additionIngredient().orElse(null), trimRecipe.baseIngredient(), trimRecipe.templateIngredient().orElse(null), trimRecipe.pattern.value()));
-
-            if (smithingRecipe instanceof SmithingTransformRecipe transformRecipe) {
-                recipeList.add(SmithingClientRecipe.transformationRecipe(smithingRecipeRecipeHolder.id().identifier(),  transformRecipe.additionIngredient().orElse(null), transformRecipe.baseIngredient(), transformRecipe.templateIngredient().orElse(null), transformRecipe.result));
+            try {
+                if (smithingRecipe instanceof SmithingTrimRecipe trimRecipe) {
+                    recipeList.add(SmithingClientRecipe.trimRecipe(smithingRecipeRecipeHolder.id().identifier(),
+                            trimRecipe.additionIngredient().orElse(null), trimRecipe.baseIngredient(),
+                            trimRecipe.templateIngredient().orElse(null), trimRecipe.pattern.value()));
+                } else if (smithingRecipe instanceof SmithingTransformRecipe transformRecipe) {
+                    recipeList.add(SmithingClientRecipe.transformationRecipe(smithingRecipeRecipeHolder.id().identifier(),
+                            transformRecipe.additionIngredient().orElse(null), transformRecipe.baseIngredient(),
+                            transformRecipe.templateIngredient().orElse(null), transformRecipe.result));
+                }
+            } catch (Exception e) {
+                // Log smithing recipes that throw out an exception on parse
+                ReliableRecipeViewer.LOGGER.atError().setCause(e).log(
+                        "Exception while parsing smithing recipe \"{}\"",
+                        smithingRecipeRecipeHolder.id().identifier());
             }
-
         });
     }
 

--- a/src/main/java/cc/cassian/rrv/client/recipe/ClientRecipeCache.java
+++ b/src/main/java/cc/cassian/rrv/client/recipe/ClientRecipeCache.java
@@ -181,7 +181,9 @@ public class ClientRecipeCache {
             try {
                 clientRecipeProvider.provide(recipes);
             } catch (Exception e) {
-                ReliableRecipeViewer.LOGGER.error("Failed to add client recipes {}, skipping it...", e.getMessage());
+                ReliableRecipeViewer.LOGGER.atError().setCause(e).log(
+                        "Failed to add client recipes from {}, skipping it...",
+                        clientRecipeProvider.getClass().getName());
                 continue;
             }
             for (int id = 0; id < recipes.size(); id++) {


### PR DESCRIPTION
When not handled properly it can cause no recipes to show up!

<details> 
  <summary>The patch fixes that by catching and logging the issue.</summary>

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.item.crafting.Ingredient.display()" because "ingredient" is null
	at knot//cc.cassian.rrv.common.recipe.inventory.SlotContent.of(SlotContent.java:334)
	at knot//cc.cassian.rrv.common.builtin.smithing.SmithingClientRecipe.transformationRecipe(SmithingClientRecipe.java:53)
	at knot//cc.cassian.rrv.client.builtin.BuiltInReliableRecipeViewerClientIntegration.lambda$addSmithingRecipes$0(BuiltInReliableRecipeViewerClientIntegration.java:306)
	at knot//com.google.common.collect.ImmutableList.forEach(ImmutableList.java:421)
	at knot//cc.cassian.rrv.client.builtin.BuiltInReliableRecipeViewerClientIntegration.addSmithingRecipes(BuiltInReliableRecipeViewerClientIntegration.java:297)
	at knot//cc.cassian.rrv.client.builtin.BuiltInReliableRecipeViewerClientIntegration.lambda$onIntegrationInitialize$4(BuiltInReliableRecipeViewerClientIntegration.java:121)
	at knot//cc.cassian.rrv.client.recipe.ClientRecipeCache.buildRecipeCache(ClientRecipeCache.java:182)
	at knot//cc.cassian.rrv.fabric.FabricClientEntrypoint.lambda$onInitializeClient$1(FabricClientEntrypoint.java:60)
	at knot//net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent.lambda$static$1(ClientRecipeSynchronizedEvent.java:34)
	at knot//net.fabricmc.fabric.impl.recipe.sync.client.RecipeSyncImplClient.onRecipeSyncPacket(RecipeSyncImplClient.java:55)
	at knot//net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon.receive(ClientPlayNetworkAddon.java:77)
	at knot//net.fabricmc.fabric.impl.networking.client.ClientPlayNetworkAddon.receive(ClientPlayNetworkAddon.java:39)
	at knot//net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon.handle(AbstractChanneledNetworkAddon.java:102)
	at knot//net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl.handler$dnk000$fabric-networking-api-v1$onCustomPayload(ClientCommonPacketListenerImpl.java:1057)
	at knot//net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl.handleCustomPayload(ClientCommonPacketListenerImpl.java)
	at knot//net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket.handle(ClientboundCustomPayloadPacket.java:49)
	at knot//net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket.handle(ClientboundCustomPayloadPacket.java:19)
	at knot//net.minecraft.network.PacketProcessor$ListenerAndPacket.mixinextras$bridge$handle$8(PacketProcessor.java)
	at knot//net.minecraft.network.PacketProcessor$ListenerAndPacket.wrapOperation$ddn000$exploitpreventer$ep$handle(PacketProcessor.java:518)
	at knot//net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:55)
	at knot//net.minecraft.network.PacketProcessor.processQueuedPackets(PacketProcessor.java:38)
	at knot//net.minecraft.client.Minecraft.runTick(Minecraft.java:1343)
	at knot//net.minecraft.client.Minecraft.run(Minecraft.java:991)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

</details>