### PR TITLE
Fix OOBE with Inventory Item Groups

### DIFF
--- a/src/main/java/cc/cassian/rrv/common/integration/ModCompat.java
+++ b/src/main/java/cc/cassian/rrv/common/integration/ModCompat.java
@@ -8,6 +8,7 @@ public class ModCompat {
 	public static final boolean ITEM_DESCRIPTIONS = RRVPlatform.INSTANCE.isModLoaded("item_descriptions");
 	public static final boolean JADE = RRVPlatform.INSTANCE.isModLoaded("jade");
 	public static final boolean WTHIT = RRVPlatform.INSTANCE.isModLoaded("wthit");
+	public static final boolean INVENTORY_ITEM_GROUPS = RRVPlatform.INSTANCE.isModLoaded("inventory_item_groups");
 
     public static boolean hasModNamespaceModsInstalled() {
         return (ITEM_DESCRIPTIONS && ItemDescriptionsCompat.modNamespaceEnabled()) ||

--- a/src/main/java/cc/cassian/rrv/common/recipe/inventory/RecipeViewMenu.java
+++ b/src/main/java/cc/cassian/rrv/common/recipe/inventory/RecipeViewMenu.java
@@ -374,6 +374,12 @@ public class RecipeViewMenu extends AbstractContainerMenu {
             }
         }
 
+        // The inventory items groups mod cannot properly handle containers menus with exactly one slot.
+        // So add a dummy slot when the inventory item groups mod is present and the menu has exactly one slot.
+        if (ModCompat.INVENTORY_ITEM_GROUPS && this.slots.size() == 1) {
+            this.addSlot(new RecipeSlot(new ViewContainer(1), 0, Integer.MIN_VALUE, Integer.MIN_VALUE, false));
+        }
+
         this.updateReferences();
     }
 


### PR DESCRIPTION
Inventory Item Groups has a method called for every slot of a container that crash if there less than 2 slots, but never get called if there is no slots.

```java
    @Unique
    private int iig$calculateIndex(Slot slot) {
        int result = 0;
        var slots = menu.slots;
        if (!slots.isEmpty() && slots.size() > 1)
            result = Main.tempItemStacks.indexOf(slots.get(1).getItem());
        if (!slots.get(0).getItem().equals(slots.get(1).getItem())) result--;
        return result + slot.index;
    }
```

So I add an extra dummy slot when the mod is detected and only one slot is present.

Can be reproduced by checking the uses of a fuel and going on the fuel tab with Inventory Item Groups mod enabled.

Source code: https://github.com/BizCub/inventory-item-groups