### PR TITLE
Fix duplicate recipes received during synchronization on NeoForge

### DIFF
--- a/src/main/java/cc/cassian/rrv/common/recipe/ServerRecipeManager.java
+++ b/src/main/java/cc/cassian/rrv/common/recipe/ServerRecipeManager.java
@@ -60,9 +60,10 @@ public class ServerRecipeManager {
     /// @param serializer The recipe serializer used for Fabric recipe synchronization.
     /// @param type The recipe type used for NeoForge recipe synchronization.
     public void synchronizeRecipeType(RecipeSerializer<?> serializer, RecipeType<?> type) {
+        //? fabric {
         if (ModCompat.FABRIC_RECIPE_API && serializer != null)
             FabricUtil.synchronizeRecipeType(serializer);
-        //? neoforge {
+        //?} else {
         /*if (type != null && !NeoForgeEntrypoint.SYNCHRONIZED_RECIPES.contains(type))
             NeoForgeEntrypoint.SYNCHRONIZED_RECIPES.add(type);
         *///?}

--- a/src/main/java/cc/cassian/rrv/fabric/FabricClientUtil.java
+++ b/src/main/java/cc/cassian/rrv/fabric/FabricClientUtil.java
@@ -1,18 +1,10 @@
 package cc.cassian.rrv.fabric;
 
 import cc.cassian.rrv.api.ReliableRecipeViewerClientPlugin;
-import cc.cassian.rrv.client.ReliableRecipeViewerClient;
-import cc.cassian.rrv.client.recipe.ClientRecipeCache;
 import cc.cassian.rrv.client.util.RRVClientUtil;
-import cc.cassian.rrv.common.recipe.util.RrvUtil;
-import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
-import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.ApiStatus;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 /// Separated out from standard Fabric classes so it can be reused for Launchpad.
 @ApiStatus.Internal
@@ -23,14 +15,5 @@ public class FabricClientUtil {
 		for (EntrypointContainer<ReliableRecipeViewerClientPlugin> container : FabricLoader.getInstance().getEntrypointContainers("rrv_client", ReliableRecipeViewerClientPlugin.class)) {
 			RRVClientUtil.initializeEntrypoint(container.getProvider().getMetadata().getId(), container.getEntrypoint());
 		}
-	}
-
-	public static void registerFabricRecipeEvents() {
-		ClientRecipeSynchronizedEvent.EVENT.register((client, recipes) -> {
-			Collection<RecipeHolder<?>> newRecipes = new ArrayList<>(recipes.recipes());
-			newRecipes.addAll(ReliableRecipeViewerClient.LOCAL_RECIPES.values());
-			ReliableRecipeViewerClient.LOCAL_RECIPES = RrvUtil.createRecipeMap(newRecipes);
-			ClientRecipeCache.INSTANCE.buildRecipeCache(true);
-		});
 	}
 }

--- a/src/main/java/cc/cassian/rrv/neoforge/NeoForgeClientEntrypoint.java
+++ b/src/main/java/cc/cassian/rrv/neoforge/NeoForgeClientEntrypoint.java
@@ -56,7 +56,6 @@ public class NeoForgeClientEntrypoint {
 		if (ModCompat.LAUNCHPAD && ModCompat.FABRIC_RECIPE_API) {
 			ReliableRecipeViewer.LOGGER.info("Initializing RRV client integration for Fabric mods through Launchpad.");
 			FabricClientUtil.initializeClient();
-			FabricClientUtil.registerFabricRecipeEvents();
 		}
         ModLoadingContext.get().registerExtensionPoint(IConfigScreenFactory.class, ()-> (mod, screen) -> new ClientConfigScreen(screen));
     }


### PR DESCRIPTION
## The issue

On NeoForge, when Launchpad & FFAPI are installed, RRV registers recipe sync requests from addons to both Fabric and NeoForge APIs, then listens to both platforms' events for received recipes and combines the results, which leads to duplicates when reconstructing the RecipeMap and an exception is thrown.

Registering with the Fabric API on Neo is unnecessary from the start (unless I missed something), because the RecipeType is already synced by NeoForge.

Listening to the Fabric event was I believe necessary because the Neo event did not provide info on synced Fabric recipes from Fabric mods that do not integrate with RRV as their recipe types were never registered to Neo's sync system. This was an issue with FFAPI that I've now fixed in version 0.155.0+26.1.2+3.3.0.

See also:
- https://github.com/Sinytra/ForgifiedFabricAPI/issues/288

## The proposal

I've updated FFAPI to use NeoForge for syncing Fabric recipes. This way, it's now possible to access all recipes through the NeoForged event alone.

This PR updates RRV's recipe sync integration to avoid duplicate errors when syncing recipes on Neo+Launchpad+FFAPI:

- Recipe sync from RRV plugins is only registered with Neo's system, not both

- Removed listener to Fabric's ClientRecipeSynchronizedEvent event as Fabric synced recipes are now available in Neo's RecipesReceivedEvent

## Testing

1. On Minecraft 26.1.2, load NeoForge, FFAPI, Launchpad, Connector and Alloyed (integrates with RRV) and Tech Reborn (does not integrate)

2. Place a breakpoint in `NeoForgeClientEntrypoint.receiveRecipes`

3. Check that `RrvUtil.createRecipeMap` does not throw a duplicate element exception and that the received recipe map contains recipes from Alloyed and Tech Reborn